### PR TITLE
add blockade based chaos test scenario

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM java:8
+MAINTAINER Gregor Uhlenheuer <kongo2002@gmail.com>
+
+# get scala + sbt
+RUN wget -nv "http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.deb" && \
+    dpkg -i scala-2.11.7.deb && \
+    apt-get update && \
+    apt-get install scala && \
+    rm scala-2.11.7.deb && \
+    \
+    wget -nv "https://dl.bintray.com/sbt/debian/sbt-0.13.9.deb" && \
+    dpkg -i sbt-0.13.9.deb && \
+    apt-get update && \
+    apt-get install sbt && \
+    rm sbt-0.13.9.deb && \
+    \
+    sbt version
+
+# load applications from the /app folder
+# to be used like: 'docker run -v $(pwd):/app ...'
+VOLUME "/app"
+WORKDIR "/app"
+
+ADD build.sbt /app/build.sbt
+RUN cd /app && sbt test:compile && rm build.sbt
+
+ENTRYPOINT ["sbt"]
+CMD ["version"]

--- a/README.md
+++ b/README.md
@@ -1,121 +1,380 @@
 Eventuate chaos testing utilities
 =================================
 
-This is very early work in progress on chaos testing utilities for [Eventuate](https://github.com/RBMHTechnology/eventuate) and [Apache Cassandra](http://cassandra.apache.org/). They support running Cassandra clusters and Eventuate applications on a single Mac OS X machine with [Docker](https://www.docker.com/) and generate failures by randomly stopping and restarting containers.
+This is very early work in progress on chaos testing utilities for [Eventuate][eventuate] and [Apache
+Cassandra](http://cassandra.apache.org/). They support running Cassandra clusters and Eventuate applications with
+[Docker][docker] and using [blockade][blockade] to easily generate failures like stopping and restarting of containers
+and introducing network failures such as partitions, packet loss and slow connections.
+
+This repository can be seen as a toolkit or collection of utilities which you can use to test your Eventuate
+applications. Moreover we are going to describe an examplary test setup that gives an introduction into these tools and
+serves as a blueprint to build your own more complex test scenarios.
+
+
+##### Blockade
+
+The test scenarios we are about to create mainly facilitate the [blockade][blockade] tool. Blockade is a utility for
+testing network failures and partitions in distributed applications. Blockade uses Docker containers to run
+application processes and manages the network from the host system to create various failure scenarios. Docker itself is
+a container engine that allows you to package and run applications in a hardware-agnostic and platform-agnostic fashion -
+often called like somewhat *lightweight virtual machines*.
+
+You can find further information on the [blockade github page][blockade] regarding its configuration and the
+possibilities you have in addition to what is mentioned in here.
+
 
 Prerequisites
 -------------
 
-### Installed Software
+#### Linux
 
-- [boot2docker](http://boot2docker.io/) 1.6.2 or higher
-- [sbt](http://www.scala-sbt.org/download.html) 0.13.x or higher
+- [Docker][docker] (tested with docker >= 1.6)
+- [blockade][blockade] (currently a fork of the original [dcm-oss/blockade](https://github.com/dcm-oss/blockade))
 
-### Started boot2docker VM
+##### Initial setup
 
-    almdudler:eventuate-chaos martin$ boot2docker start
-    Waiting for VM and Docker daemon to start...
-    ..........ooooooooo
-    Started.
+Given your Docker daemon is running and you have [blockade][blockade] in your `$PATH` you are basically ready to go. All
+you have to do once is to pull or build the necessary Docker containers the test cluster is based on:
 
-### Custom route
+``` bash
+# cassandra image
+$ docker pull cassandra:2.2.3
 
-By default, docker containers, running in the boot2docker VM, are not directly accessible from Mac OS. To make them accessible, packets targeted at docker container IP addresses must be routed to the boot2docker VM. Assuming that Docker containers have IP addresses `172.17.x.x`, a route to the boot2docker VM is added with: 
+# sbt + scala + java8 base image
+$ docker build -t eventuate-chaos/sbt .
+```
 
-    almdudler:eventuate-chaos martin$ sudo route -n add 172.17.0.0/16 `boot2docker ip`
-    add net 172.17.0.0: gateway 192.168.59.103
+After that is done you can start the minimal docker DNS container that is used to identify the containers with each
+other:
+
+    $ ./start-dns.sh
+
+This script will look for the default `docker0` network interface and start a `dnsdock` image on port 53 for DNS
+discovery. You may have to specify the location to your *docker socket* via `$DOCKER_SOCKET` in case the script does not
+find it by itself:
+
+    $ DOCKER_SOCKET=/var/run/docker.sock ./start-dns.sh
+
+These steps only have to be taken once for the initial bootstrapping.
+
+
+#### Mac OS
+
+- [Vagrant][vagrant] (tested with 1.7.4)
+- [VirtualBox](https://www.virtualbox.org/)
+
+
+##### Initial setup
+
+As Docker does not run natively on Mac OS you have to use an existing [docker machine](https://docs.docker.com/machine/)
+setup and follow the steps under [Linux](#linux) or use the pre-configured [Vagrant][vagrant] image that ships with this
+repository. If you choose the latter you just have to build the image by running `vagrant up` and ssh into your new
+machine:
+
+```bash
+$ vagrant up
+$ vagrant ssh
+
+# inside your virtual machine you can find the repository contents
+# mounted under /vagrant as usual
+cd /vagrant
+```
+
+
+Example test setup
+------------------
+
+The examplary test setup we are describing in the following consists of 2 basic components:
+
+- **Eventuate test appliation**:
+
+    This is the Eventuate application we are actually testing with. It is an
+    [EventsourcedActor](http://rbmhtechnology.github.io/eventuate/user-guide.html#event-sourced-actors) that continually
+    (every 2 seconds) emits an event that increments an internal counter by persisting it changes. You can find its
+    implementation in [ChaosActor.scala](./src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosActor.scala). The
+    container which the scala application is running in is named `location-1`.
+
+- **Cassandra cluster**:
+
+    This cassandra cluster contains 3 nodes each running in its own Docker container. The seed node `c1` is the
+    initially started one the remaining nodes `c2` and `c3` connect with.
+
+
+#### Configuration
+
+The test setup described above is encoded in the `blockade.yml` YAML configuration file that is used by
+[blockade][blockade] to manage the test cluster:
+
+``` yaml
+containers:
+  c1:
+    image: cassandra:2.2.3
+
+  c2:
+    image: cassandra:2.2.3
+    start_delay: 60
+    links:
+      c1: "c1"
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  c3:
+    image: cassandra:2.2.3
+    start_delay: 60
+    links:
+      c1: "c1"
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  location-1:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosActor -d"]
+    volumes:
+      "${PWD}": "/app"
+    links: [ "c2", "c3" ]
+    environment:
+      CASSANDRA_NODES: "c1.cassandra.docker,c2.cassandra.docker,c3.cassandra.docker"
+```
+
 
 Running a Cassandra cluster
 ---------------------------
 
-### Manual failure generation
+### blockade chaos cluster
 
-One way of running a local Cassandra cluster is using the scripts `cluster-start.sh` and `cluster-stop.sh`. These scripts and other `docker` commands below require a shell to be initialized with: 
+Now that you have all prerequisites fulfilled you can start up the [blockade][blockade] test cluster as it is configured
+in the `blockade.yml` shipped with this repository. From this point on you may freely experiment and modify all given
+parameters and configurations as this is just a toolkit to get you started as quickly as possible.
 
-    almdudler:eventuate-chaos martin$ eval `boot2docker shellinit`
-  
-For starting a Cassandra cluster with four nodes, for example, run:
+> Note that all blockade commands require root permissions.
 
-    almdudler:eventuate-chaos martin$ ./cluster-start.sh 4
-    cassandra-1
-    cassandra-2
-    cassandra-3
-    cassandra-4
-
-Running the command for the first time downloads all required Docker images which may take a while. If no argument is given, three nodes are started by default. The script prints the names of the started containers (`cassandra-<i>`) each containing a cluster node. For stopping node three, for example, run: 
-
-    almdudler:eventuate-chaos martin$ docker stop cassandra-3
-    cassandra-3
-
-For sending node three a `SIGKILL` instead, run:
-
-    almdudler:eventuate-chaos martin$ docker kill cassandra-3
-    cassandra-3
-
-For starting that node again, run:
-
-    almdudler:eventuate-chaos martin$ docker start cassandra-3
-    cassandra-3
-
-For stopping the whole cluster and removing all containers, run: 
- 
-    almdudler:eventuate-chaos martin$ ./cluster-stop.sh 
-    cassandra-1
-    cassandra-2
-    cassandra-3
-    cassandra-4
-
-### Random failure generation
-
-For running a cluster with random node failures, start the [`ChaosCluster`](https://github.com/RBMHTechnology/eventuate-chaos/blob/master/src/main/scala/com/rbmhtechnology/eventuate/chaos/ChaosCluster.scala) application with sbt:
-
-    almdudler:eventuate-chaos martin$ sbt
-    [info] Loading global plugins from /Users/martin/.sbt/0.13/plugins
-    [info] Loading project definition from /Users/martin/eventuate-chaos/project
-    [info] Set current project to eventuate-chaos (in build file:/Users/martin/eventuate-chaos/)
-    > runMain com.rbmhtechnology.eventuate.chaos.ChaosCluster
-    [info] Running com.rbmhtechnology.eventuate.chaos.ChaosCluster 
-    Writing /Users/martin/.boot2docker/certs/boot2docker-vm/ca.pem
-    Writing /Users/martin/.boot2docker/certs/boot2docker-vm/cert.pem
-    Writing /Users/martin/.boot2docker/certs/boot2docker-vm/key.pem
-    cassandra-1
-    cassandra-2
-    cassandra-3
-    cassandra-4
-    Cluster started. Press any key to start chaos ...
-
-By default, a four node cluster is started (see also [reference.conf](https://github.com/RBMHTechnology/eventuate-chaos/blob/master/src/main/resources/reference.conf) for further details). Pressing any key, after the cluster started, generates chaos by randomly stopping and (re)starting nodes, except the seed node (`cassandra-1`): 
-
-    cassandra-4
-    cassandra-2
-    Node(s) stopped. Press any key to stop cluster ...
-    cassandra-4
-    cassandra-2
-    Node(s) started. Press any key to stop cluster ...
-    cassandra-3
-    Node(s) stopped. Press any key to stop cluster ...
-    cassandra-3
-    Node(s) started. Press any key to stop cluster ...
-
-Pressing any key a second time stops the cluster and removes all containers:
-
-    cassandra-1
-    cassandra-2
-    cassandra-3
-    cassandra-4
-    Cluster stopped
-    [success] Total time: 77 s, completed 11.07.2015 17:12:22
-
-Obtaining the seed node address
--------------------------------
-
-From the command line, the IP address of the cluster seed node (`cassandra-1`) can be obtained with: 
-
-    almdudler:eventuate-chaos martin$ docker inspect --format='{{ .NetworkSettings.IPAddress }}' cassandra-1
-    172.17.0.1
-
-In Scala applications, the `seedAddress` method of the [`ChaosCommands`](https://github.com/RBMHTechnology/eventuate-chaos/blob/master/src/main/scala/com/rbmhtechnology/eventuate/chaos/ChaosCommands.scala) trait can be used to obtain the `InetAddress` of the seed node: 
-
-```scala
-def seedAddress(): Try[InetAddress]
+```bash
+$ sudo blockade up
 ```
+
+Depending on the cassandra version (> 2.1) you have to configure a reasonable startup delay for every cassandra node
+like 60 seconds (see the
+[documentation](https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_add_node_to_cluster_t.html) for
+further information). This may increase the initial startup time a lot. Once all nodes are up and running you can
+inspect your running cluster via `blockade status`:
+
+```bash
+$ sudo blockade status
+NODE            CONTAINER ID    STATUS  IP              NETWORK    PARTITION
+c1              8ccf90e8f76e    UP      172.17.0.3      NORMAL
+c2              5c65f3ca62ec    UP      172.17.0.5      NORMAL
+c3              4b630db6a19e    UP      172.17.0.4      NORMAL
+location-1      bb8c89f615ef    UP      172.17.0.6      NORMAL
+```
+
+### failures
+
+From now on you may introduce any kind of failure the [blockade][blockade] tool supports.
+
+##### partition one cassandra node
+
+``` bash
+$ sudo blockade partition c2
+NODE            CONTAINER ID    STATUS  IP              NETWORK    PARTITION
+c1              8ccf90e8f76e    UP      172.17.0.3      NORMAL     2
+c2              5c65f3ca62ec    UP      172.17.0.5      NORMAL     1
+c3              4b630db6a19e    UP      172.17.0.4      NORMAL     2
+location-1      bb8c89f615ef    UP      172.17.0.6      NORMAL     2
+```
+
+
+##### partition two cassandra nodes
+
+As you can see in the `PARTITION` column of the command output all cassandra nodes are separated from each other while
+the test application (`location-1`) can reach the cassandra node `c2` only.
+
+``` bash
+$ sudo blockade partition c1 c3
+NODE            CONTAINER ID    STATUS  IP              NETWORK    PARTITION
+c1              8ccf90e8f76e    UP      172.17.0.3      NORMAL     1
+c2              5c65f3ca62ec    UP      172.17.0.5      NORMAL     3
+c3              4b630db6a19e    UP      172.17.0.4      NORMAL     2
+location-1      bb8c89f615ef    UP      172.17.0.6      NORMAL     3
+```
+
+
+##### flaky network connection of the Eventuate node
+
+``` bash
+$ sudo blockade flaky location-1
+NODE            CONTAINER ID    STATUS  IP              NETWORK    PARTITION
+c1              8ccf90e8f76e    UP      172.17.0.3      NORMAL     1
+c2              5c65f3ca62ec    UP      172.17.0.5      NORMAL     3
+c3              4b630db6a19e    UP      172.17.0.4      NORMAL     2
+location-1      bb8c89f615ef    UP      172.17.0.6      FLAKY      3
+```
+
+##### restart of nodes
+
+You may also restart one or multiple nodes and inspect the effect on the Eventuate application as well:
+
+    $ sudo blockade restart c2 c3
+
+#### Inspect test application output
+
+While playing with the conditions of the test cluster you can see the Eventuate application output its current state
+(being the actual counter value) on stdout. This is my personal preference but I like to inspect the current Eventuate
+node's status in a [tmux](https://tmux.github.io/) split window while I modify the cluster's condition with `tmux
+split-window "docker logs -f location-1"`:
+
+
+```
+counter = 65 (recovery = false)
+counter = 66 (recovery = false)
+persist failure 696: Not enough replica available for query at consistency QUORUM (2 required but only 1 alive)
+persist failure 697: Not enough replica available for query at consistency QUORUM (2 required but only 1 alive)
+counter = 67 (recovery = false)
+...
+counter = 74 (recovery = false)
+counter = 75 (recovery = false)
+persist failure 698: Cassandra timeout during write query at consistency QUORUM (2 replica were required but only 1 acknowledged the write)
+counter = 76 (recovery = false)
+counter = 77 (recovery = false)
+```
+
+
+#### Expected behavior
+
+Just to recapture the current setup, we are dealing with a cassandra cluster of 3 nodes and the Eventuate test
+application is configured to initialize its keyspace with a `replication-factor` of 3 (you may find further information
+on data replication in the
+[cassandra
+documentation](http://docs.datastax.com/en/cassandra/2.2/cassandra/architecture/archDataDistributeReplication.html)).
+As in this example read and write operations are processed on a `QUORUM` consistency level (see
+[documentation](http://docs.datastax.com/en/cassandra/2.2/cassandra/dml/dmlConfigConsistency.html)) persisting an
+event may only succeed if at least 2 of 3 cassandra nodes are reachable from the Eventuate application.
+
+Please keep in mind that any of the following failure scenarios may take a while until the state between application and
+the cassandra cluster has settled to a stable condition (i.e. reconnect timeouts ...).
+
+
+##### Persisting while one node is down/not reachable
+
+Consequently we expect the application to be able to persist any event while any or no cassandra node is partitioned
+from the test application container. You may inspect the state of the application with `docker logs -f location-1` like
+mentioned above or trigger a health check via the `./interact.py` python script:
+
+``` bash
+# on success the current state counter of the 'ChaosActor' is written to stdout
+$ ./interact.py
+250
+
+# the check script exits with a non-zero status code on failure
+$ echo $?
+0
+```
+
+The health check of the `interact.py` script instructs the test application to persist a special `HealthCheck` event and
+returns with the current counter state if the persist of that given event succeeded within 1 second. The script
+basically sends a minor command (`"persist"`) via TCP on port 8080 - so you may achieve the same result via `telnet` as
+well.
+
+
+##### No persistence while a minority of nodes available/reachable
+
+On the contrary the Eventuate application must not be able to persist an event while only a minority of the cassandra
+nodes is available to itself. This happens as soon as you partition a combination of any two nodes like:
+
+``` bash
+# this command creates a partition of c1 and c3 nodes leaving
+# the test application with only one reachable node (c2) behind
+$ sudo blockade partition c1,c3
+```
+
+
+##### Reconnect to healthy state
+
+As soon as you remove all existing partitions or give the test application access to at least 2 cassandra nodes the
+event persistence should pick up its work again:
+
+``` bash
+# remove all existing partitions
+$ sudo blockade join
+```
+
+
+##### Examplary test script
+
+Just to give a small example on how you might automate such tests you can find a very simple shell script in
+[scenarios/simple-partitions.sh](./scenarios/simple-partitions.sh) that checks for the expectations described above:
+
+``` bash
+$ scenarios/simple-partitions.sh
+*** checking working persistence with 1 node partition each
+partition of cassandra 'c1'
+waiting 40 seconds for cluster to settle...
+checking health...
+partition of cassandra 'c2'
+waiting 40 seconds for cluster to settle...
+checking health...
+partition of cassandra 'c3'
+waiting 40 seconds for cluster to settle...
+checking health...
+*** checking non-working persistence with 2 node partitions
+partition of test application + 'c1'
+waiting 40 seconds for cluster to settle...
+checking health...
+waiting till cluster is up and running...
+partition of test application + 'c2'
+waiting 40 seconds for cluster to settle...
+checking health...
+waiting till cluster is up and running...
+partition of test application + 'c3'
+waiting 40 seconds for cluster to settle...
+checking health...
+waiting till cluster is up and running...
+*** checking final reconnect
+test successfully finished
+```
+
+
+Auxiliary notes
+-----------------
+
+Below you can find some random remarks on problems or issues you may run into while chaos testing with the
+aforementioned methods and tools.
+
+
+#### DNS docker image
+
+As mentioned before we are using the docker image `tonistiigi/dnsdock` in order to establish a lightweight DNS service
+among the docker containers. This is especially useful when containers are referencing each other in a fashion that
+would form a circular dependency of [docker links](http://docs.docker.com/engine/userguide/networking/dockernetworks/).
+
+You may even integrate this DNS docker service into your host's DNS so that you can reference your containers by name.
+Usually you just have to add the docker interface's IP to your `/etc/resolv.conf` for that to work.
+
+This docker container can be started with the `start-dns.sh` script and is reachable under the name `dnsdock`. This
+means you can observe its current status via
+
+    $ docker logs dnsdock
+
+
+#### Initial startup time
+
+In case your are using cassandra version `> 2.1` (i.e. `2.2.3` like our example) you have to delay the startup of the
+cassandra nodes so that the node topology has enough time to settle in. You may alternatively test with an older version
+like `2.1.6` and get rid of those `start_delay` values in your `blockade.yml` resulting in much faster startup times. If
+that makes sense depends completely on what you intend to test. The [cassandra
+documentation](https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_add_node_to_cluster_t.html) provides
+further information on that issue.
+
+
+#### Interaction with docker commands
+
+While you are using [blockade][blockade] as your 'manager' of your test cluster you are completely free to use other
+docker containers in a normal docker-fashion like you are used to. However you **should not** `start`/`stop`/`restart`
+containers of your blockade cluster using the usual `docker <cmd>` commands. As [blockade][blockade] has to keep track
+of the network devices each container is associated with you should use the respective blockade commands like `blockade
+start`, `blockade stop`, `blockade restart`, `blockade up` and `blockade destroy` instead.
+
+
+[docker]: https://www.docker.com/
+[blockade]: https://github.com/kongo2002/blockade
+[vagrant]: https://www.vagrantup.com/
+[eventuate]: https://github.com/RBMHTechnology/eventuate

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,49 @@
+
+VAGRANTFILE_API_VERSION = "2"
+BOX_NAME = ENV['BOX_NAME'] || "ubuntu/trusty64"
+script = <<SCRIPT
+#!/bin/bash -e
+
+if [ ! -f /etc/default/docker ]; then
+  echo "/etc/default/docker not found -- is docker installed?" >&2
+  exit 1
+fi
+
+# get setuptools
+apt-get update
+apt-get install python-setuptools
+
+# get blockade
+if [ -d "/blockade" ]; then
+    cd /blockade
+    git fetch origin
+    git reset --hard origin/master
+else
+    git clone https://github.com/kongo2002/blockade.git /blockade
+fi
+
+# build blockade
+cd /blockade
+python setup.py develop
+
+# pull required docker images
+docker pull cassandra:2.2.3
+docker pull tonistiigi/dnsdock
+
+docker build -t eventuate-chaos/sbt /vagrant
+
+# start dns if necessary
+/vagrant/start-dns.sh -f
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = BOX_NAME
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--name", "eventuate-chaos", "--memory", "8192", "--cpus", "2"]
+  end
+
+  config.vm.provision "docker"
+  config.vm.provision "shell", inline: script
+end

--- a/blockade.yml
+++ b/blockade.yml
@@ -1,0 +1,30 @@
+containers:
+  c1:
+    image: cassandra:2.2.3
+
+  c2:
+    image: cassandra:2.2.3
+    start_delay: 60
+    links: ["c1"]
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  c3:
+    image: cassandra:2.2.3
+    start_delay: 60
+    links: ["c1"]
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  location-1:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosActor -d"]
+    volumes:
+      "${PWD}": "/app"
+    ports:
+      8080: 8080
+    links: ["c2", "c3"]
+    environment:
+      CASSANDRA_NODES: "c1.cassandra.docker,c2.cassandra.docker,c3.cassandra.docker"
+
+# vim: set et sw=2 sts=2:

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,11 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
-resolvers += "Eventuate Releases" at "https://dl.bintray.com/rbmhtechnology/maven"
+resolvers += "OJO Snapshots" at "https://oss.jfrog.org/oss-snapshot-local"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka"  %% "akka-actor"    % "2.4-M2",
-  "com.typesafe.akka"  %% "akka-remote"   % "2.4-M2" % "test",
-  "com.rbmhtechnology" %% "eventuate"     % "0.2.1"  % "test",
-  "org.slf4j"           % "slf4j-log4j12" % "1.7.9"  % "test"
+  "com.typesafe.akka"  %% "akka-remote"   % "2.4-M2"       % "test",
+  "com.rbmhtechnology" %% "eventuate"     % "0.5-SNAPSHOT" % "test",
+  "org.slf4j"           % "slf4j-log4j12" % "1.7.9"        % "test"
 )

--- a/interact.py
+++ b/interact.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import argparse
+import socket
+import sys
+
+
+BUFFER_SIZE = 64
+
+def request(ip, port, message):
+    success = False
+
+    # connect
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1.0)
+    sock.connect((ip, port))
+
+    # request
+    sock.send(message)
+    data = ''
+
+    try:
+        while True:
+            received = sock.recv(BUFFER_SIZE)
+            if not received:
+                return data
+            data += received
+        return data
+    except socket.timeout:
+        return data
+    finally:
+        # disconnect
+        sock.close()
+
+def is_healthy(ip, port, message, verbose=True):
+    try:
+        data = request(ip, port, message)
+    except socket.error:
+        return False
+
+    if data and len(data) > 0:
+        if verbose:
+            print(data)
+        return True
+    return False
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser(description='Simple interaction with a TCP endpoint')
+    PARSER.add_argument('-p', '--port', type=int, default=8080, help='port of the remote endpoint')
+    PARSER.add_argument('-i', '--ip', default='127.0.0.1', help='IP of the remote endpoint')
+    PARSER.add_argument('message', nargs='*', default=['persist'])
+
+    ARGS = PARSER.parse_args()
+    MESSAGE = ' '.join(ARGS.message)
+
+    if not is_healthy(ARGS.ip, ARGS.port, MESSAGE):
+        sys.exit(1)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9

--- a/scenarios/simple-partitions.sh
+++ b/scenarios/simple-partitions.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+CASSANDRAS="c1 c2 c3"
+SETTLE_DELAY=${SETTLE_DELAY:-40}
+
+function settle() {
+    echo "waiting $SETTLE_DELAY seconds for cluster to settle..."
+    sleep $SETTLE_DELAY
+}
+
+function wait_till_healthy() {
+    echo "waiting till cluster is up and running..."
+    while ! ./interact.py >/dev/null 2>&1; do
+        sleep 2
+    done
+}
+
+wait_till_healthy
+
+echo "*** checking working persistence with 1 node partition each"
+
+for cassandra in $CASSANDRAS; do
+    echo "partition of cassandra '$cassandra'"
+
+    sudo blockade partition $cassandra
+    settle
+
+    echo "checking persistence..."
+    ./interact.py >/dev/null
+done
+
+echo "*** checking non-working persistence with 2 node partitions"
+
+for cassandra in $CASSANDRAS; do
+    echo "partition of chaos application + '$cassandra'"
+
+    sudo blockade partition location-1,$cassandra
+    settle
+
+    echo "checking persistence..."
+    ./interact.py >/dev/null 2>&1 && (echo "persistence working when it shouldn't" && exit 1)
+
+    # reconnect cluster for next partition
+    sudo blockade join
+    wait_till_healthy
+done
+
+echo "*** checking final reconnect"
+
+./interact.py >/dev/null
+
+echo "test successfully finished"

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosActorInterface.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosActorInterface.scala
@@ -1,0 +1,63 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import java.net.InetSocketAddress
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.io.IO
+import akka.io.Tcp
+import akka.util.ByteString
+import akka.pattern.ask
+import akka.util.Timeout
+import com.rbmhtechnology.eventuate.chaos.ChaosActorInterface.HealthCheckResult
+import scala.concurrent.duration._
+import com.rbmhtechnology.eventuate.chaos.ChaosActorInterface.HealthCheck
+
+import scala.util.Failure
+import scala.util.Success
+
+
+object ChaosActorInterface {
+  case class HealthCheck(requester: ActorRef)
+  case class HealthCheckResult(state: Int, requester: ActorRef)
+}
+
+class ChaosActorInterface(chaosActor: ActorRef) extends Actor {
+  val port = 8080
+  val endpoint = new InetSocketAddress(port)
+
+  implicit val ec = context.dispatcher
+  implicit val timeout = Timeout(1.seconds)
+
+  IO(Tcp)(context.system) ! Tcp.Bind(self, endpoint)
+
+  println(s"Now listening on port $port")
+
+  def receive: Receive = {
+    case Tcp.Connected(remote, _) =>
+      sender ! Tcp.Register(self)
+
+    case Tcp.Received(bs) =>
+      val content = bs.utf8String
+
+      if (content.startsWith("persist")) {
+        val requester = sender
+        val check = HealthCheck(requester)
+
+        (chaosActor ? check).mapTo[HealthCheckResult] onComplete {
+          case Success(result) =>
+            result.requester ! Tcp.Write(ByteString(result.state.toString))
+            result.requester ! Tcp.Close
+          case Failure(e) =>
+            requester ! Tcp.Close
+        }
+      } else if (content.startsWith("quit")) {
+        context.system.terminate()
+      } else {
+        sender ! Tcp.Close
+      }
+
+    case Tcp.Closed =>
+    case Tcp.PeerClosed =>
+  }
+}

--- a/start-dns.sh
+++ b/start-dns.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+DOCKER_IFACE=`ip a s docker0 | grep 'inet ' | cut -d ' ' -f6 | cut -d/ -f1`
+
+if [ -z "$DOCKER_IFACE" ]; then
+    echo unable to determine docker network interface
+    exit 1
+fi
+
+echo "using docker interface: $DOCKER_IFACE"
+
+DOCKER_SOCKET=${DOCKER_SOCKET:-/run/docker.sock}
+
+if [ ! -S "$DOCKER_SOCKET" ]; then
+    echo "did not find docker socket, please specify \$DOCKER_SOCKET"
+    exit 1
+fi
+
+# update resolv.conf if necessary
+if ! grep "$DOCKER_IFACE" /etc/resolv.conf >/dev/null; then
+    if [ "$1" = "-f" ]; then
+        sed -i "1i nameserver $DOCKER_IFACE" /etc/resolv.conf
+    else
+        echo "you may want to add 'nameserver $DOCKER_IFACE' to your resolv.conf"
+    fi
+fi
+
+if ! docker top dnsdock >/dev/null 2>/dev/null; then
+    echo "dnsdock not running yet"
+    if docker ps -a | grep dnsdock >/dev/null 2>&1; then
+        echo "restarting dnsdock..."
+        docker start dnsdock >/dev/null
+    else
+        echo "starting dnsdock..."
+        docker run -d --name dnsdock -p "${DOCKER_IFACE}:53:53/udp" -v $DOCKER_SOCKET:$DOCKER_SOCKET tonistiigi/dnsdock >/dev/null
+    fi
+else
+    echo dnsdock is already running
+fi


### PR DESCRIPTION
Hi,

this is the first step towards some chaos testing using the [blockade](https://github.com/kongo2002/blockade) tool. The PR includes a Vagrantfile, Dockerfile and an examplary blockade configuration + test script to get started as fast as possible.

Cheers,
Gregor
