### PR TITLE
CRDT based counter chaos tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-.idea*
-*.log
-*.iml
 *.env
+*.iml
+*.log
+*.pyc
+.idea*
+.vagrant
 target/

--- a/build.sbt
+++ b/build.sbt
@@ -14,3 +14,18 @@ libraryDependencies ++= Seq(
   "com.rbmhtechnology" %% "eventuate"     % "0.5-SNAPSHOT" % "test",
   "org.slf4j"           % "slf4j-log4j12" % "1.7.9"        % "test"
 )
+
+val runNobootcp =
+  InputKey[Unit]("run-nobootcp", "Runs main classes without Scala library on the boot classpath")
+
+runNobootcp <<= runNobootcpInputTask(Runtime)
+runNobootcp <<= runNobootcpInputTask(Test)
+
+def runNobootcpInputTask(configuration: Configuration) = inputTask {
+  (argTask: TaskKey[Seq[String]]) => (argTask, streams, fullClasspath in configuration) map { (at, st, cp) =>
+    val runCp = cp.map(_.data).mkString(java.io.File.pathSeparator)
+    val runOpts = Seq("-classpath", runCp) ++ at
+    val result = Fork.java.fork(None, runOpts, None, Map(), false, LoggedOutput(st.log)).exitValue()
+    if (result != 0) error("Run failed")
+  }
+}

--- a/crdt-counter-partitions.py
+++ b/crdt-counter-partitions.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import random
+import sys
+
+import blockade.cli
+import interact
+
+
+HOST = '127.0.0.1'
+MAX_VALUE = 100
+
+
+def check_counters(nodes):
+    if len(nodes) < 1:
+        raise ValueError('no nodes given')
+
+    counters = []
+    for node, port in nodes.items():
+        counter = interact.request(HOST, port, 'get')
+        equal = all(x == counter for x in counters)
+
+        if not equal:
+            print('Counter of node "%s" [%s] does not match with other counters: %s' %
+                  (node, counter, str(counters)))
+            return None
+        counters.append(counter)
+
+    # all counters are the same -> return the first one for reference
+    return int(counters[0])
+
+
+class CounterOperation(interact.Operation):
+
+    def __init__(self):
+        self.state = {'counter': 0}
+
+    def init(self, host, nodes):
+        # get first counter value
+        counter = int(interact.request(host, nodes.values()[0], 'get'))
+        self.state['counter'] = counter
+
+        return self.state
+
+    def operation(self, idx, state):
+        op = random.choice(['inc', 'dec'])
+        value = random.randint(1, MAX_VALUE)
+
+        if op == 'inc':
+            state['counter'] += value
+        else:
+            state['counter'] -= value
+
+        return '%s %d' % (op, value)
+
+    def get_counter(self):
+        return self.state['counter']
+
+
+if __name__ == '__main__':
+    SETTLE_TIMEOUT = 30
+    PARSER = argparse.ArgumentParser(description='start CRDT-counter chaos test')
+    PARSER.add_argument('-i', '--iterations', type=int, default=30, help='number of failure/partition iterations')
+    PARSER.add_argument('--interval', type=float, default=0.1, help='delay between requests')
+    PARSER.add_argument('-l', '--locations', type=int, default=3, help='number of locations')
+    PARSER.add_argument('-d', '--delay', type=int, default=10, help='delay between each random partition')
+
+    ARGS = PARSER.parse_args()
+
+    # we are making some assumptions in here:
+    # every location is named 'location<id>' and its TCP port (8080)
+    # is mapped to the host port '10000+<id>'
+    NODES = dict(('location%d' % idx, 10000+idx) for idx in xrange(1, ARGS.locations+1))
+    OP = CounterOperation()
+
+    if not interact.requests_with_chaos(OP, HOST, NODES, ARGS.iterations, ARGS.interval, SETTLE_TIMEOUT, ARGS.delay):
+        sys.exit(1)
+
+    EXPECTED_VALUE = OP.get_counter()
+    COUNTER_VALUE = check_counters(NODES)
+
+    if COUNTER_VALUE is None:
+        sys.exit(1)
+    else:
+        print('All %d nodes converged to the counter value: %d' % (len(NODES), COUNTER_VALUE))
+
+    if COUNTER_VALUE != EXPECTED_VALUE:
+        print('Expected counter value: %d; actual %d' % (EXPECTED_VALUE, COUNTER_VALUE))
+        sys.exit(1)
+
+    print('Counter value (%d) matches up correctly' % EXPECTED_VALUE)
+

--- a/interact.py
+++ b/interact.py
@@ -1,15 +1,69 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import socket
 import sys
+import time
+import threading
+import random
+
+import blockade.cli
 
 
 BUFFER_SIZE = 64
+SETTLE_TIMEOUT = 60
+FAILURE_DELAY = 5
+
+
+class Operation(object):
+    '''Abstract base class that is used for "RequestWorker" operations
+    '''
+    def init(self, host, nodes):
+        pass
+
+    def operation(self, iteration, state):
+        '''
+        This method will be called on very iteration of a worker request. You
+        may modify the passed 'state' object.
+        '''
+        raise NotImplementedError("you have to implement 'Operation.operation'")
+
+
+class RequestWorker(threading.Thread):
+    def __init__(self, host, nodes, operation, operations=None, interval=0.5):
+        threading.Thread.__init__(self)
+
+        self.host = host
+        self.nodes = nodes
+        self.operations = operations
+        self.interval = interval
+        self.is_cancelled = False
+        self.operation = operation
+        self.iterations = 0
+        self.state = None
+
+    def run(self):
+        # initialize operation's state (if given)
+        self.state = self.operation.init(self.host, self.nodes)
+        ports = self.nodes.values()
+
+        while (self.operations is None or self.operations > 0) and not self.is_cancelled:
+            if self.operations:
+                self.operations -= 1
+
+            port = random.choice(ports)
+            request(self.host, port, self.operation.operation(self.iterations, self.state))
+
+            self.iterations += 1
+            time.sleep(self.interval)
+
+    def cancel(self):
+        self.is_cancelled = True
+
 
 def request(ip, port, message):
-    success = False
-
     # connect
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(1.0)
@@ -17,20 +71,21 @@ def request(ip, port, message):
 
     # request
     sock.send(message)
-    data = ''
+    data = []
 
     try:
         while True:
             received = sock.recv(BUFFER_SIZE)
             if not received:
-                return data
-            data += received
-        return data
+                break
+            data.append(received)
     except socket.timeout:
-        return data
+        pass
     finally:
         # disconnect
         sock.close()
+    return ''.join(data)
+
 
 def is_healthy(ip, port, message, verbose=True):
     try:
@@ -43,6 +98,86 @@ def is_healthy(ip, port, message, verbose=True):
             print(data)
         return True
     return False
+
+
+def wait_to_be_running(host, nodes):
+    print('Waiting for %d nodes to be up and running...' % (len(nodes)))
+    while True:
+        all_running = all(is_healthy(host, port, 'get', False) for port in nodes.values())
+        if all_running:
+            return True
+        time.sleep(2)
+
+
+def _print_partitions(partitions):
+    if len(partitions) < 1:
+        print('Cluster joined')
+    else:
+        for idx, part in enumerate(partitions):
+            print('Partition %d: %s' % (idx+1, ', '.join(part)))
+
+
+def requests_with_chaos(operation, host, nodes, iterations, interval, settle=SETTLE_TIMEOUT, failure_delay=FAILURE_DELAY):
+    print('Chaos iterations: %d' % iterations)
+    print('Request interval: %.3f sec' % interval)
+    print('Failure delay: %d sec' % failure_delay)
+
+    print('Nodes:')
+    for node in nodes.keys():
+        print('  ' + node)
+
+    # wait for system to be ready and initialized
+    wait_to_be_running(host, nodes)
+
+    try:
+        worker = RequestWorker(host, nodes, operation, interval=interval)
+        worker.start()
+
+        # initialize blockade interface
+        cfg = blockade.cli.load_config('blockade.yml')
+        blk = blockade.cli.get_blockade(cfg)
+
+        def random_network(node):
+            failure = random.choice([blk.fast, blk.flaky, blk.slow])
+            failure([node], None)
+
+        delay = failure_delay / 2
+
+        for _ in xrange(iterations):
+            # trigger some random partition(s)
+            part = blk.random_partition()
+            _print_partitions(part)
+            print('-' * 25)
+            time.sleep(delay)
+
+            # trigger random network failure (slow, flaky...)
+            random_network(random.choice(nodes.keys()))
+            time.sleep(delay)
+
+    except (KeyboardInterrupt, blockade.errors.BlockadeError) as err:
+        worker.cancel()
+        worker.join()
+
+        if err is KeyboardInterrupt:
+            blk.join()
+            blk.fast(None, None)
+            print('Test interrupted')
+            return False
+        else:
+            raise
+
+    worker.cancel()
+    worker.join()
+
+    print('Joining cluster - waiting %d seconds to settle...' % settle)
+    blk.join()
+    blk.fast(None, None)
+
+    time.sleep(settle)
+
+    print('Processed %d requests in the meantime' % worker.iterations)
+    return True
+
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(description='Simple interaction with a TCP endpoint')

--- a/scenarios/counter-cassandra-acyclic/blockade.yml
+++ b/scenarios/counter-cassandra-acyclic/blockade.yml
@@ -1,0 +1,58 @@
+containers:
+  c1:
+    image: cassandra:2.2.3
+    #neutral: true
+
+  c11:
+    image: cassandra:2.2.3
+    #neutral: true
+    links: ["c1"]
+    start_delay: 60
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  c12:
+    image: cassandra:2.2.3
+    #neutral: true
+    links: ["c1"]
+    start_delay: 60
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  location1:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location1 location2.sbt.docker"]
+    ports:
+      10001: 8080
+    links: ["c11"]
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location1.sbt.docker"
+      CASSANDRA_NODES: "c1.cassandra.docker,c11.cassandra.docker,c12.cassandra.docker"
+
+  location2:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location2 location1.sbt.docker location3.sbt.docker"]
+    ports:
+      10002: 8080
+    links: ["c11"]
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location2.sbt.docker"
+      CASSANDRA_NODES: "c1.cassandra.docker,c11.cassandra.docker,c12.cassandra.docker"
+
+  location3:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location3 location2.sbt.docker"]
+    ports:
+      10003: 8080
+    links: ["c11"]
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location3.sbt.docker"
+      CASSANDRA_NODES: "c1.cassandra.docker,c11.cassandra.docker,c12.cassandra.docker"
+
+# vim: set et sw=2 sts=2:

--- a/scenarios/counter-cassandra/blockade.yml
+++ b/scenarios/counter-cassandra/blockade.yml
@@ -1,0 +1,60 @@
+containers:
+  c1:
+    image: cassandra:2.2.3
+    neutral: false
+
+  c11:
+    image: cassandra:2.2.3
+    neutral: false
+    links: ["c1"]
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  c12:
+    image: cassandra:2.2.3
+    neutral: false
+    links: ["c11"]
+    start_delay: 60
+    environment:
+      CASSANDRA_SEEDS: "c1.cassandra.docker"
+
+  location1:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location1 location2.sbt.docker location3.sbt.docker"]
+    neutral: false
+    ports:
+      10001: 8080
+    links: ["c12"]
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location1.sbt.docker"
+      CASSANDRA_NODES: "c1.cassandra.docker,c11.cassandra.docker,c12.cassandra.docker"
+
+  location2:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location2 location1.sbt.docker location3.sbt.docker"]
+    neutral: false
+    ports:
+      10002: 8080
+    links: ["c12"]
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location2.sbt.docker"
+      CASSANDRA_NODES: "c1.cassandra.docker,c11.cassandra.docker,c12.cassandra.docker"
+
+  location3:
+    image: eventuate-chaos/sbt
+    command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location3 location1.sbt.docker location2.sbt.docker"]
+    neutral: false
+    ports:
+      10003: 8080
+    links: ["c12"]
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location3.sbt.docker"
+      CASSANDRA_NODES: "c1.cassandra.docker,c11.cassandra.docker,c12.cassandra.docker"
+
+# vim: set et sw=2 sts=2:

--- a/scenarios/counter/README.markdown
+++ b/scenarios/counter/README.markdown
@@ -1,0 +1,172 @@
+
+# Chaos test of distributed operation-based Counter CRDT
+
+This scenario is another example of an [Eventuate][eventuate] application that is being tested under network failures
+and partitions.
+
+> In case you haven't read the basic README of this repository already you should definitely do so before continuing
+> with this test scenario to gain as much benefit of the following explanations as possible.
+
+
+## Test setup
+
+This time the application is a [operation-based Counter
+CRDT](https://github.com/RBMHTechnology/eventuate/blob/master/src/main/scala/com/rbmhtechnology/eventuate/crdt/Counter.scala)
+service that is distributed among three Eventuate locations (each represented by
+a separate node). The persistence of the event-sourced services is driven by
+[LevelDB event
+logs](http://rbmhtechnology.github.io/eventuate/reference/event-log.html#leveldb-storage-backend).
+
+
+#### Participating nodes
+
+Each Eventuate location accepts control commands on its local TCP port `8080` that is exposed to the host machine on the
+following ports:
+
+- `location-1`: TCP port `8080` -> host port `10001`
+- `location-2`: TCP port `8080` -> host port `10002`
+- `location-3`: TCP port `8080` -> host port `10003`
+
+
+#### Scenario
+
+The distributed counter CRDT that is managed by the tested application can be incremented and decremented by issuing a
+simple command via the TCP port of the respective node.
+
+- `inc 15`: increment the counter by `15`
+- `dec 2`: decrement by `2`
+- `get`: retrieve the current counter value
+
+Once again you may use the `interact.py` helper script that is shipped with this repository:
+
+``` bash
+# start up test scenario
+scenarios/counter $ sudo blockade up
+
+# increment counter at location-2
+scenarios/counter $ ../../interact.py -p 10002 inc 20
+20
+
+# decrement counter at location-3
+scenarios/counter $ ../../interact.py -p 10003 dec 4
+16
+
+# request counter value from location-1
+scenarios/counter $ ../../interact.py -p 10001 get
+16
+```
+
+
+#### Scripted chaos test
+
+Just to give you another example on how you might automate your chaos testing you may use the
+`crdt-counter-partitions.py` script to generate random network failures while requesting counter operations of the test
+application:
+
+``` bash
+scenarios/counter $ sudo ../../crdt-counter-partitions.py -i 5 --interval 0.001
+Chaos iterations: 5
+Request interval: 0.001 sec
+Nodes:
+  location-1
+  location-2
+  location-3
+Waiting for 3 nodes to be up and running...
+Starting requests...
+Partition 1: location-1
+Partition 2: location-3
+Partition 3: location-2
+--------------------
+Partition 1: location-3, location-1
+Partition 2: location-2
+--------------------
+Partition 1: location-3
+Partition 2: location-1
+Partition 3: location-2
+--------------------
+Cluster joined
+--------------------
+Partition 1: location-3
+Partition 2: location-2, location-1
+--------------------
+Joining cluster - waiting 30 seconds to settle...
+Processed 6631 requests in the meantime
+Counter value (9037) matches up correctly
+```
+
+The expected and tested behavior is to end up with all Eventuate nodes responding with the same counter value after the
+network failures have been resolved. Even though during the test run nodes are partitioned from each other the counters
+are supposed to converge to the same correct value. Moreover the actual counter value is compared with the value that is
+expected by calculating all requests that are made during the test. Of course this value won't match up in case you
+issue commands by yourself during the test setup.
+
+The default settings of the test script are to inject random partitions on the network every 10 seconds and moreover
+toggling one random node's network to being *slow*, *flaky* or *fast* (more information on [blockade][blockade])
+separated by 5 seconds each. These failures are injected on 30 iterations by default. In the meantime every 0.1 seconds
+a request for either a *decrement* or *increment* operation is triggered towards one random Eventuate node.
+
+Some parameters like request interval (`--interval`), number of network failures to inject (`--iterations`), the number
+of participating Eventuate nodes (`--locations`) and the delay between each failure (`--delay`) may be configured at the
+command line as well:
+
+``` bash
+$ ./crdt-counter-partitions.py -h
+usage: crdt-counter-partitions.py [-h] [-i ITERATIONS] [--interval INTERVAL]
+                                  [-l LOCATIONS] [-d DELAY]
+
+start CRDT-counter chaos test
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i ITERATIONS, --iterations ITERATIONS
+                        number of failure/partition iterations
+  --interval INTERVAL   delay between requests
+  -l LOCATIONS, --locations LOCATIONS
+                        number of locations
+  -d DELAY, --delay DELAY
+                        delay between each random partition
+```
+
+> Please note the example script requires root permissions as it directly hooks into the blockade toolkit which itself
+> needs administrative rights to instrument the underlying network.
+
+
+### Configuration
+
+As usual the configuration is done via a [blockade][blockade] configuration file:
+
+``` yaml
+containers:
+  location-1:
+    image: eventuate-chaos/sbt
+    command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounter location-1 location-2.sbt.docker location-3.sbt.docker"]
+    ports:
+      10001: 8080
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location-1.sbt.docker"
+
+  location-2:
+    image: eventuate-chaos/sbt
+    command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounter location-2 location-1.sbt.docker location-3.sbt.docker"]
+    ports:
+      10002: 8080
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location-2.sbt.docker"
+
+  location-3:
+    image: eventuate-chaos/sbt
+    command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounter location-3 location-1.sbt.docker location-2.sbt.docker"]
+    ports:
+      10003: 8080
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location-3.sbt.docker"
+```
+
+[blockade]: https://github.com/kongo2002/blockade
+[eventuate]: https://github.com/RBMHTechnology/eventuate

--- a/scenarios/counter/blockade.yml
+++ b/scenarios/counter/blockade.yml
@@ -1,0 +1,32 @@
+containers:
+  location1:
+    image: eventuate-chaos/sbt
+    command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounterLeveldb location1 location2.sbt.docker location3.sbt.docker"]
+    ports:
+      10001: 8080
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location1.sbt.docker"
+
+  location2:
+    image: eventuate-chaos/sbt
+    command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounterLeveldb location2 location1.sbt.docker location3.sbt.docker"]
+    ports:
+      10002: 8080
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location2.sbt.docker"
+
+  location3:
+    image: eventuate-chaos/sbt
+    command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounterLeveldb location3 location1.sbt.docker location2.sbt.docker"]
+    ports:
+      10003: 8080
+    volumes:
+      "${PWD}/../..": /app
+    environment:
+      HOSTNAME: "location3.sbt.docker"
+
+# vim: set et sw=2 sts=2:

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosActorInterface.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosActorInterface.scala
@@ -1,18 +1,14 @@
 package com.rbmhtechnology.eventuate.chaos
 
-import java.net.InetSocketAddress
-
-import akka.actor.Actor
 import akka.actor.ActorRef
-import akka.io.IO
 import akka.io.Tcp
 import akka.util.ByteString
 import akka.pattern.ask
 import akka.util.Timeout
 import com.rbmhtechnology.eventuate.chaos.ChaosActorInterface.HealthCheckResult
-import scala.concurrent.duration._
 import com.rbmhtechnology.eventuate.chaos.ChaosActorInterface.HealthCheck
 
+import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 
@@ -22,42 +18,19 @@ object ChaosActorInterface {
   case class HealthCheckResult(state: Int, requester: ActorRef)
 }
 
-class ChaosActorInterface(chaosActor: ActorRef) extends Actor {
-  val port = 8080
-  val endpoint = new InetSocketAddress(port)
-
-  implicit val ec = context.dispatcher
+class ChaosActorInterface(chaosActor: ActorRef) extends ChaosInterface {
   implicit val timeout = Timeout(1.seconds)
 
-  IO(Tcp)(context.system) ! Tcp.Bind(self, endpoint)
+  def handleCommand = {
+    case ("persist", None, recv) =>
+      val check = HealthCheck(recv)
 
-  println(s"Now listening on port $port")
-
-  def receive: Receive = {
-    case Tcp.Connected(remote, _) =>
-      sender ! Tcp.Register(self)
-
-    case Tcp.Received(bs) =>
-      val content = bs.utf8String
-
-      if (content.startsWith("persist")) {
-        val requester = sender
-        val check = HealthCheck(requester)
-
-        (chaosActor ? check).mapTo[HealthCheckResult] onComplete {
-          case Success(result) =>
-            result.requester ! Tcp.Write(ByteString(result.state.toString))
-            result.requester ! Tcp.Close
-          case Failure(e) =>
-            requester ! Tcp.Close
-        }
-      } else if (content.startsWith("quit")) {
-        context.system.terminate()
-      } else {
-        sender ! Tcp.Close
+      (chaosActor ? check).mapTo[HealthCheckResult] onComplete {
+        case Success(result) =>
+          result.requester ! Tcp.Write(ByteString(result.state.toString))
+          result.requester ! Tcp.Close
+        case Failure(e) =>
+          recv ! Tcp.Close
       }
-
-    case Tcp.Closed =>
-    case Tcp.PeerClosed =>
   }
 }

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCassandraSetup.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCassandraSetup.scala
@@ -1,0 +1,35 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import akka.actor.ActorSystem
+import com.rbmhtechnology.eventuate.ReplicationEndpoint
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLog
+import com.typesafe.config.ConfigFactory
+
+trait ChaosCassandraSetup extends ChaosSetup {
+
+  def config(hostname: String, seeds: Seq[String]) = baseConfig(hostname)
+    .withFallback(ConfigFactory.parseString(
+    s"""
+       |eventuate.log.cassandra.contact-points = [${seeds.map(quote).mkString(",")}]
+       |eventuate.log.cassandra.replication-factor = ${seeds.size}
+       |eventuate.log.cassandra.keyspace = "ev_$name"
+       |eventuate.log.cassandra.index-update-limit = 16
+       |eventuate.log.cassandra.read-consistency = "QUORUM"
+       |eventuate.log.cassandra.write-consistency = "QUORUM"
+     """.stripMargin))
+
+  def cassandras = sys.env.get("CASSANDRA_NODES").map(_.split(","))
+    .getOrElse(Array("c1.cassandra.docker", "c2.cassandra.docker"))
+
+  def getSystem = ActorSystem.create("location", config(hostname, cassandras))
+
+  // create and activate eventuate replication endpoint
+  def getEndpoint(implicit system: ActorSystem) = {
+    val ep = new ReplicationEndpoint(name,
+      Set(ReplicationEndpoint.DefaultLogName),
+      CassandraEventLog.props(_),
+      connections)
+    ep.activate()
+    ep
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCounter.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCounter.scala
@@ -1,0 +1,21 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import akka.actor.Props
+import com.rbmhtechnology.eventuate.ReplicationEndpoint
+import com.rbmhtechnology.eventuate.crdt.CounterService
+
+object ChaosCounterLeveldb extends ChaosLeveldbSetup {
+  implicit val system = getSystem
+  val endpoint = getEndpoint
+
+  val service = new CounterService[Int](name, endpoint.logs(ReplicationEndpoint.DefaultLogName))
+  system.actorOf(Props(new ChaosCounterInterface(service)))
+}
+
+object ChaosCounterCassandra extends ChaosCassandraSetup {
+  implicit val system = getSystem
+  val endpoint = getEndpoint
+
+  val service = new CounterService[Int](name, endpoint.logs(ReplicationEndpoint.DefaultLogName))
+  system.actorOf(Props(new ChaosCounterInterface(service)))
+}

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCounterInterface.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCounterInterface.scala
@@ -1,0 +1,28 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import com.rbmhtechnology.eventuate.crdt.CounterService
+
+class ChaosCounterInterface(service: CounterService[Int]) extends ChaosInterface {
+  val testId = "test"
+
+  def handleCommand = {
+    case ("inc", Some(v), recv) =>
+      service.update(testId, v)
+        .map(value => reply(value.toString, recv))
+        .onFailure {
+          case err => log.error(err, "Failed to increment counter by {}", v)
+        }
+    case ("dec", Some(v), recv) =>
+      service.update(testId, -v)
+        .map(value => reply(value.toString, recv))
+        .onFailure {
+          case err => log.error(err, "Failed to decrement counter by {}", v)
+        }
+    case ("get", None, recv) =>
+      service.value(testId)
+        .map(value => reply(value.toString, recv))
+        .onFailure {
+          case err => log.error(err, "Failed to retrieve counter value")
+        }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosInterface.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosInterface.scala
@@ -1,0 +1,51 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import java.net.InetSocketAddress
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.io.IO
+import akka.io.Tcp
+import akka.util.ByteString
+
+abstract class ChaosInterface extends Actor with ActorLogging {
+  val port = 8080
+  val endpoint = new InetSocketAddress(port)
+  val command = """(?s)(\w+)\s+(\d+).*""".r
+
+  implicit val ec = context.dispatcher
+
+  IO(Tcp)(context.system) ! Tcp.Bind(self, endpoint)
+
+  println(s"Now listening on port $port")
+
+  def handleCommand: PartialFunction[(String, Option[Int], ActorRef), Unit]
+
+  protected def reply(message: String, receiver: ActorRef) = {
+    receiver ! Tcp.Write(ByteString(message))
+    receiver ! Tcp.Close
+  }
+
+  def receive: Receive = {
+    case Tcp.Connected(remote, _) =>
+      sender ! Tcp.Register(self)
+
+    case Tcp.Received(bs) =>
+      val content = bs.utf8String
+
+      content match {
+        case command(c, value) if handleCommand.isDefinedAt(c, Some(value.toInt), sender) =>
+          handleCommand(c, Some(value.toInt), sender)
+        case c if c.startsWith("quit") =>
+          context.system.terminate()
+        case c if handleCommand.isDefinedAt(c, None, sender) =>
+          handleCommand(c, None, sender)
+        case _ =>
+          sender ! Tcp.Close
+      }
+
+    case Tcp.Closed =>
+    case Tcp.PeerClosed =>
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosLeveldbSetup.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosLeveldbSetup.scala
@@ -1,0 +1,27 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import akka.actor.ActorSystem
+import com.rbmhtechnology.eventuate.ReplicationEndpoint
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog
+import com.typesafe.config.ConfigFactory
+
+trait ChaosLeveldbSetup extends ChaosSetup {
+
+  def config(hostname: String) = baseConfig(hostname)
+    .withFallback(ConfigFactory.parseString(
+      s"""
+         |eventuate.snapshot.filesystem.dir = /tmp/test-snapshot
+         |eventuate.log.leveldb.dir = /tmp/test-log
+     """.stripMargin))
+
+  def getSystem = ActorSystem.create("location", config(hostname))
+
+  // create and activate eventuate replication endpoint
+  def getEndpoint(implicit system: ActorSystem) = {
+    val ep = new ReplicationEndpoint(name,
+      Set(ReplicationEndpoint.DefaultLogName),
+      LeveldbEventLog.props(_), connections)
+    ep.activate()
+    ep
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSet.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSet.scala
@@ -1,0 +1,14 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import akka.actor.Props
+import com.rbmhtechnology.eventuate.ReplicationEndpoint
+import com.rbmhtechnology.eventuate.crdt.ORSetService
+
+object ChaosSet extends ChaosCassandraSetup {
+  implicit val system = getSystem
+  val endpoint = getEndpoint
+
+  val service = new ORSetService[Int](name, endpoint.logs(ReplicationEndpoint.DefaultLogName))
+  system.actorOf(Props(new ChaosSetInterface(service)))
+}
+

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSetInterface.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSetInterface.scala
@@ -1,0 +1,28 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import akka.actor.ActorRef
+import akka.util.Timeout
+
+import com.rbmhtechnology.eventuate.crdt.ORSetService
+
+import scala.concurrent.duration._
+
+class ChaosSetInterface(service: ORSetService[Int]) extends ChaosInterface {
+  val setId = "test"
+
+  implicit val timeout = Timeout(1.seconds)
+
+  private def writeSet(set: Set[Int], receiver: ActorRef) = {
+    reply(s"[${set.mkString(",")}]", receiver)
+  }
+
+  def handleCommand = {
+    case ("add", Some(v), recv) =>
+      service.add(setId, v).map(x => writeSet(x, recv))
+    case ("remove", Some(v), recv) =>
+      service.remove(setId, v).map(x => writeSet(x, recv))
+    case ("get", None, recv) =>
+      service.value(setId).map(x => writeSet(x, recv))
+  }
+}
+

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSetup.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSetup.scala
@@ -1,0 +1,51 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import akka.actor.ActorSystem
+import com.rbmhtechnology.eventuate.ReplicationConnection
+import com.rbmhtechnology.eventuate.ReplicationEndpoint
+import com.typesafe.config.ConfigFactory
+
+trait ChaosSetup extends App {
+
+  def getSystem: ActorSystem
+
+  def getEndpoint(implicit system: ActorSystem): ReplicationEndpoint
+
+  protected def baseConfig(hostname: String) = ConfigFactory.parseString(
+    s"""
+       |akka.actor.provider = "akka.remote.RemoteActorRefProvider"
+       |akka.remote.enabled-transports = ["akka.remote.netty.tcp"]
+       |akka.remote.netty.tcp.hostname = "$hostname"
+       |akka.remote.netty.tcp.port = 2552
+       |akka.test.single-expect-default = 10s
+       |akka.loglevel = "ERROR"
+       |eventuate.log.batching.batch-size-limit = 16
+       |eventuate.log.replication.batch-size-max = 16
+       |eventuate.log.replication.read-timeout = 3s
+       |eventuate.log.replication.retry-delay = 3s
+       |akka.remote.netty.tcp.maximum-frame-size = 1024000b
+     """.stripMargin)
+
+  protected def quote(str: String) = "\"" + str + "\""
+
+  def name = {
+    if (args == null || args.length < 1) {
+      Console.err.println("no <nodename> specified")
+      sys.exit(1)
+    } else {
+      args(0)
+    }
+  }
+
+  def hostname = sys.env.getOrElse("HOSTNAME", s"$name.sbt.docker")
+
+  // replication connection to other node(s)
+  def connections = args.drop(1).map { conn =>
+    conn.split(":") match {
+      case Array(host, port) =>
+        ReplicationConnection(host, port.toInt)
+      case Array(host) =>
+        ReplicationConnection(host, 2552)
+    }
+  }.toSet
+}


### PR DESCRIPTION
Hi,

this is the next iteration of chaos testing - CRDT based counter service on three nodes (in the example). 

The PR includes a draft of a very similar test scenario using an `ORSetService` with Cassandra backends. Although that one is not documented and polished yet I would leave it in here if you don't mind (although removing it isn't too much work either ;-)).

I'm eager to here your feedback on this one!

Cheers,
Gregor
