### PR TITLE
update configs to latest blockade version 0.2.0

### DIFF
--- a/blockade.yml
+++ b/blockade.yml
@@ -1,9 +1,11 @@
 containers:
   c1:
     image: cassandra:2.2.3
+    container_name: c1
 
   c2:
     image: cassandra:2.2.3
+    container_name: c2
     start_delay: 60
     links: ["c1"]
     environment:
@@ -11,12 +13,14 @@ containers:
 
   c3:
     image: cassandra:2.2.3
+    container_name: c3
     start_delay: 60
     links: ["c1"]
     environment:
       CASSANDRA_SEEDS: "c1.cassandra.docker"
 
   location-1:
+    container_name: location-1
     image: eventuate-chaos/sbt
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosActor -d"]
     volumes:

--- a/scenarios/counter-cassandra-acyclic/blockade.yml
+++ b/scenarios/counter-cassandra-acyclic/blockade.yml
@@ -1,10 +1,12 @@
 containers:
   c1:
     image: cassandra:2.2.3
+    container_name: c1
     #neutral: true
 
   c11:
     image: cassandra:2.2.3
+    container_name: c11
     #neutral: true
     links: ["c1"]
     start_delay: 60
@@ -13,6 +15,7 @@ containers:
 
   c12:
     image: cassandra:2.2.3
+    container_name: c12
     #neutral: true
     links: ["c1"]
     start_delay: 60
@@ -21,6 +24,7 @@ containers:
 
   location1:
     image: eventuate-chaos/sbt
+    container_name: location1
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location1 location2.sbt.docker"]
     ports:
       10001: 8080
@@ -33,6 +37,7 @@ containers:
 
   location2:
     image: eventuate-chaos/sbt
+    container_name: location2
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location2 location1.sbt.docker location3.sbt.docker"]
     ports:
       10002: 8080
@@ -45,6 +50,7 @@ containers:
 
   location3:
     image: eventuate-chaos/sbt
+    container_name: location3
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location3 location2.sbt.docker"]
     ports:
       10003: 8080

--- a/scenarios/counter-cassandra/blockade.yml
+++ b/scenarios/counter-cassandra/blockade.yml
@@ -1,10 +1,12 @@
 containers:
   c1:
     image: cassandra:2.2.3
+    container_name: c1
     neutral: false
 
   c11:
     image: cassandra:2.2.3
+    container_name: c11
     neutral: false
     links: ["c1"]
     environment:
@@ -12,6 +14,7 @@ containers:
 
   c12:
     image: cassandra:2.2.3
+    container_name: c12
     neutral: false
     links: ["c11"]
     start_delay: 60
@@ -20,6 +23,7 @@ containers:
 
   location1:
     image: eventuate-chaos/sbt
+    container_name: location1
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location1 location2.sbt.docker location3.sbt.docker"]
     neutral: false
     ports:
@@ -33,6 +37,7 @@ containers:
 
   location2:
     image: eventuate-chaos/sbt
+    container_name: location2
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location2 location1.sbt.docker location3.sbt.docker"]
     neutral: false
     ports:
@@ -46,6 +51,7 @@ containers:
 
   location3:
     image: eventuate-chaos/sbt
+    container_name: location3
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosCounterCassandra location3 location1.sbt.docker location2.sbt.docker"]
     neutral: false
     ports:

--- a/scenarios/counter/blockade.yml
+++ b/scenarios/counter/blockade.yml
@@ -1,6 +1,7 @@
 containers:
   location1:
     image: eventuate-chaos/sbt
+    container_name: location1
     command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounterLeveldb location1 location2.sbt.docker location3.sbt.docker"]
     ports:
       10001: 8080
@@ -11,6 +12,7 @@ containers:
 
   location2:
     image: eventuate-chaos/sbt
+    container_name: location2
     command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounterLeveldb location2 location1.sbt.docker location3.sbt.docker"]
     ports:
       10002: 8080
@@ -21,6 +23,7 @@ containers:
 
   location3:
     image: eventuate-chaos/sbt
+    container_name: location3
     command: ["test:run-nobootcp com.rbmhtechnology.eventuate.chaos.ChaosCounterLeveldb location3 location1.sbt.docker location2.sbt.docker"]
     ports:
       10003: 8080

--- a/scenarios/state-cassandra/blockade.yml
+++ b/scenarios/state-cassandra/blockade.yml
@@ -1,11 +1,13 @@
 containers:
   c1:
     image: cassandra:2.2.3
+    container_name: c1
     neutral: false
     #holy: true
 
   c11:
     image: cassandra:2.2.3
+    container_name: c11
     neutral: false
     #holy: true
     links: ["c1"]
@@ -14,6 +16,7 @@ containers:
 
   c12:
     image: cassandra:2.2.3
+    container_name: c12
     neutral: false
     #holy: true
     links: ["c11"]
@@ -23,6 +26,7 @@ containers:
 
   location1:
     image: eventuate-chaos/sbt
+    container_name: location1
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosStateCassandra location1 location2.sbt.docker location3.sbt.docker"]
     neutral: false
     ports:
@@ -36,6 +40,7 @@ containers:
 
   location2:
     image: eventuate-chaos/sbt
+    container_name: location2
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosStateCassandra location2 location1.sbt.docker location3.sbt.docker"]
     neutral: false
     ports:
@@ -49,6 +54,7 @@ containers:
 
   location3:
     image: eventuate-chaos/sbt
+    container_name: location3
     command: ["test:run-main com.rbmhtechnology.eventuate.chaos.ChaosStateCassandra location3 location1.sbt.docker location2.sbt.docker"]
     neutral: false
     ports:


### PR DESCRIPTION
Hi,

with the latest blockade version `0.2.0` we have to specify the container names explicitly. Otherwise the containers would be prefixed with a 'blockade run id' which makes DNS discovery of the containers impossible.

Cheers,
Gregor
