### PR TITLE
add node restarts to test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prerequisites
 #### Linux
 
 - [Docker][docker] (tested with docker >= 1.6)
-- [blockade][blockade] (currently a fork of the original [dcm-oss/blockade](https://github.com/dcm-oss/blockade))
+- [blockade][blockade] (>= 0.2.0, currently a fork of the original [dcm-oss/blockade](https://github.com/dcm-oss/blockade))
 
 ##### Initial setup
 

--- a/crdt-counter-partitions.py
+++ b/crdt-counter-partitions.py
@@ -14,24 +14,40 @@ HOST = '127.0.0.1'
 MAX_VALUE = 100
 
 
+def get_counter(host, port):
+    value = interact.request(host, port, 'get')
+    if value:
+        return int(value)
+    return None
+
+
 def check_counters(nodes):
     if len(nodes) < 1:
         raise ValueError('no nodes given')
 
     counters = []
     for node, port in nodes.items():
-        counter = interact.request(HOST, port, 'get')
+        counter = get_counter(HOST, port)
         equal = all(x == counter for x in counters)
 
         if not equal:
             print('Counter of node "%s" [%s] does not match with other counters: %s' %
-                  (node, counter, str(counters)))
+                  (node, counter, counters))
             return None
         counters.append(counter)
 
     # all counters are the same -> return the first one for reference
-    return int(counters[0])
+    return counters[0]
 
+
+def dump_logs(nodes):
+    if len(nodes) < 1:
+        raise ValueError('no nodes given')
+
+    for node, port in nodes.items():
+        interact.request(HOST, port, 'dump')
+
+    return ''
 
 class CounterOperation(interact.Operation):
 
@@ -39,10 +55,6 @@ class CounterOperation(interact.Operation):
         self.state = {'counter': 0}
 
     def init(self, host, nodes):
-        # get first counter value
-        counter = int(interact.request(host, nodes.values()[0], 'get'))
-        self.state['counter'] = counter
-
         return self.state
 
     def operation(self, node, idx, state):
@@ -56,17 +68,19 @@ class CounterOperation(interact.Operation):
 
         return '%s %d' % (op, value)
 
-    def get_counter(self):
+    def get_diff(self):
         return self.state['counter']
 
 
 if __name__ == '__main__':
-    SETTLE_TIMEOUT = 30
     PARSER = argparse.ArgumentParser(description='start CRDT-counter chaos test')
     PARSER.add_argument('-i', '--iterations', type=int, default=30, help='number of failure/partition iterations')
     PARSER.add_argument('--interval', type=float, default=0.1, help='delay between requests')
     PARSER.add_argument('-l', '--locations', type=int, default=3, help='number of locations')
     PARSER.add_argument('-d', '--delay', type=int, default=10, help='delay between each random partition')
+    PARSER.add_argument('--settle', type=int, default=60, help='number of seconds to wait for settling')
+    PARSER.add_argument('-r', '--runners', type=int, default=1, help='number of request runners')
+    PARSER.add_argument('--restarts', default=0.2, type=float, help='restart probability (in %%)')
 
     ARGS = PARSER.parse_args()
 
@@ -74,19 +88,27 @@ if __name__ == '__main__':
     # every location is named 'location<id>' and its TCP port (8080)
     # is mapped to the host port '10000+<id>'
     NODES = dict(('location%d' % idx, 10000+idx) for idx in xrange(1, ARGS.locations+1))
-    OP = CounterOperation()
+    OPS = [CounterOperation() for _ in xrange(ARGS.runners)]
 
-    if not interact.requests_with_chaos(OP, HOST, NODES, ARGS.iterations, ARGS.interval, SETTLE_TIMEOUT, ARGS.delay):
+    interact.wait_to_be_running(HOST, NODES)
+
+    INITIAL_COUNTER = check_counters(NODES)
+    if INITIAL_COUNTER is None:
         sys.exit(1)
 
-    EXPECTED_VALUE = OP.get_counter()
+    if not interact.requests_with_chaos(OPS, HOST, NODES, ARGS.iterations, ARGS.interval, ARGS.settle, ARGS.delay, ARGS.restarts):
+        sys.exit(1)
+
+    DIFF = sum(op.get_diff() for op in OPS)
     COUNTER_VALUE = check_counters(NODES)
+    #dump_logs(NODES)
 
     if COUNTER_VALUE is None:
         sys.exit(1)
     else:
         print('All %d nodes converged to the counter value: %d' % (len(NODES), COUNTER_VALUE))
 
+    EXPECTED_VALUE = INITIAL_COUNTER + DIFF
     if COUNTER_VALUE != EXPECTED_VALUE:
         print('Expected counter value: %d; actual %d' % (EXPECTED_VALUE, COUNTER_VALUE))
         sys.exit(1)

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/Analysis.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/Analysis.scala
@@ -1,0 +1,114 @@
+package com.rbmhtechnology.eventuate.chaos
+
+import scala.collection.immutable.Seq
+import scala.io.Source
+
+object Analysis extends App {
+  case class Record(logId: String = "", writeType: String = "", sequenceNr: Long = -1L, emitterId: String = "", emitterCtr: Int = -1, delta: Int = 0)
+
+  private val UpdateOpPattern =
+    """^UpdateOp\((-?\d+)\)""".r
+
+  def ar = args(0)
+
+  def delta(operation: String): Int = operation match {
+    case UpdateOpPattern(d) => d.toInt
+    case _ => throw new Exception(s"unknown operation $operation")
+  }
+
+  def record(write: String): Record = {
+    val elems = write.split(" ")
+    Record(elems(0), elems(1), elems(2).toLong, elems(3), elems(4).toInt, delta(elems(5)))
+  }
+
+  def writes(file: String): Seq[String] = {
+    Source.fromFile(file).getLines().filter(_.startsWith("-->")).map(_.substring(4)).toVector
+  }
+
+  def records(file:String): Seq[Record] =
+    writes(file).map(record)
+
+  val all = List(
+    records(s"results/r${ar}-location1.txt"),
+    records(s"results/r${ar}-location2.txt"),
+    records(s"results/r${ar}-location3.txt"))
+
+  val writes =
+    all.map(_.filterNot(_.writeType == "dmp"))
+
+  val dumps =
+    all.map(_.filter(_.writeType == "dmp"))
+
+  println()
+  println("--- Counters (from writes) ---")
+    writes.map(_.map(_.delta).sum).foreach(println)
+
+  println()
+  println("--- Counters (from dumps) ---")
+  dumps.map(_.map(_.delta).sum).foreach(println)
+
+  def compareRecords(i: Int, j: Int): Unit = {
+    val li = s"location${i+1}"
+    val lj = s"location${j+1}"
+
+    println()
+    println(s"--- Records comparison $li - $lj ---")
+    writes(i).filter(_.emitterId == li).zipAll(writes(j).filter(_.emitterId == li), Record(), Record()) foreach {
+      case (r1, r2) if r1.emitterCtr == r2.emitterCtr => println(f"  $r1%-55s $r2%-55s")
+      case (r1, r2)                                   => println(f"! $r1%-55s $r2%-55s")
+    }
+  }
+
+  def compareLogs(i: Int, j: Int): Unit = {
+    val li = s"location${i+1}"
+    val lj = s"location${j+1}"
+
+    println()
+    println(s"--- Logs comparison $li - $lj ---")
+    dumps(i).filter(_.emitterId == li).zipAll(dumps(j).filter(_.emitterId == li), Record(), Record()) foreach {
+      case (r1, r2) if r1.emitterCtr == r2.emitterCtr => println(f"  $r1%-55s $r2%-55s")
+      case (r1, r2)                                   => println(f"! $r1%-55s $r2%-55s")
+    }
+  }
+
+  def compareRecordsWithLog(i: Int): Unit = {
+    val li = s"location${i+1}"
+
+    println()
+    println(s"--- Records - log comparison $li ---")
+    writes(i).filter(_.emitterId == li).zipAll(dumps(i).filter(_.emitterId == li), Record(), Record()) foreach {
+      case (r1, r2) if r1.emitterCtr == r2.emitterCtr => println(f"  $r1%-55s $r2%-55s")
+      case (r1, r2)                                   => println(f"! $r1%-55s $r2%-55s")
+    }
+  }
+
+  def detectReps(i: Int): Unit = {
+    val li = s"location${i+1}"
+
+    println()
+    println(s"--- Reps $li ---")
+    writes(i).filter(w => w.writeType == "rep" && w.emitterId == li).foreach(println)
+  }
+
+  0 to 2 foreach { i =>
+    val j = (i+1) % 3
+    val k = (i+2) % 3
+    compareRecords(i, j)
+    compareRecords(i, k)
+  }
+
+  0 to 2 foreach { i =>
+    val j = (i+1) % 3
+    val k = (i+2) % 3
+    compareLogs(i, j)
+    compareLogs(i, k)
+  }
+
+  0 to 2 foreach { i =>
+    compareRecordsWithLog(i)
+  }
+
+  0 to 2 foreach { i =>
+    detectReps(i)
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCassandraSetup.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCassandraSetup.scala
@@ -16,6 +16,8 @@ trait ChaosCassandraSetup extends ChaosSetup {
        |eventuate.log.cassandra.index-update-limit = 16
        |eventuate.log.cassandra.read-consistency = "QUORUM"
        |eventuate.log.cassandra.write-consistency = "QUORUM"
+       |eventuate.log.cassandra.init-retry-max = 50
+       |eventuate.log.cassandra.connect-retry-max = 50
      """.stripMargin))
 
   def cassandras = sys.env.get("CASSANDRA_NODES").map(_.split(","))

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCounterInterface.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosCounterInterface.scala
@@ -24,5 +24,8 @@ class ChaosCounterInterface(service: CounterService[Int]) extends ChaosInterface
         .onFailure {
           case err => log.error(err, "Failed to retrieve counter value")
         }
+    case ("dump", None, recv) =>
+      service.log ! "dump"
+      recv ! ""
   }
 }

--- a/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSetup.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/chaos/ChaosSetup.scala
@@ -19,10 +19,9 @@ trait ChaosSetup extends App {
        |akka.remote.netty.tcp.port = 2552
        |akka.test.single-expect-default = 10s
        |akka.loglevel = "INFO"
-       |eventuate.log.batching.batch-size-limit = 16
-       |eventuate.log.replication.batch-size-max = 16
-       |eventuate.log.replication.read-timeout = 3s
-       |eventuate.log.replication.retry-delay = 3s
+       |eventuate.log.write-batch-size = 16
+       |eventuate.log.read-timeout = 3s
+       |eventuate.log.retry-delay = 3s
        |akka.remote.netty.tcp.maximum-frame-size = 1024000b
      """.stripMargin)
 


### PR DESCRIPTION
Hi,

this PR includes
- node restarts in test scenarios (configurable via `--restarts 0.4`, defaulting to a probability of 0.2)
- parallel request workers (i.e. `-r 10` for 10 request runners)
- analysis helpers (i.e. `dump_logs`)

Cheers,
Gregor
